### PR TITLE
Untar firefox if the previous package has expired

### DIFF
--- a/libraries/firefox_package.rb
+++ b/libraries/firefox_package.rb
@@ -86,7 +86,10 @@ class Chef
 
       execute 'untar-firefox' do
         command "tar --strip-components=1 -xjf #{filename} -C #{dest_path}"
-        not_if { ::File.exist?(::File.join(dest_path, 'firefox')) }
+        not_if do
+          firefox_bin = ::File.join(dest_path, 'firefox')
+          ::File.exist?(firefox_bin) && ::File.mtime(firefox_bin) > Time.now - new_resource.splay
+        end
       end
     end
 


### PR DESCRIPTION
**NOTE** looks like the kitchen run is going to fail here.

cc @rhass-r7 looks like `chef exec kitchen test -d always` fails on master too.

---
# Verification steps
- [ ] Upload this cookbook (`--no-freeze`)
- [ ] Deploy the cookbook to `testci`
- [ ] Converge chef on any test system that has either `recipe[nexpose_jenkins::node_linux]` or `recipe[nexpose_jenkins::node_windows]` in the runlist.
- [ ] Ensure that the latest firefox and firefox ESR package(s) are untar'd and symlinked properly.
